### PR TITLE
Add RSpec-based command testing infrastructure

### DIFF
--- a/lib/cog/command.rb
+++ b/lib/cog/command.rb
@@ -1,5 +1,5 @@
-
 require 'json'
+require 'cog/exceptions'
 
 class Cog
   class Command
@@ -38,6 +38,9 @@ class Cog
       accumulate_input if config[:input] == :accumulate
       run_command
       response.send
+    rescue Cog::Error => e
+      STDERR.puts(e.message)
+      exit 1
     end
 
     def env_var(var, suffix: nil, required: false, failure_message: nil)
@@ -53,8 +56,7 @@ class Cog
     end
 
     def fail(message)
-      STDERR.puts(message)
-      exit 1
+      raise Cog::Error, message
     end
 
     def self.input(value=nil)

--- a/lib/cog/exceptions.rb
+++ b/lib/cog/exceptions.rb
@@ -1,0 +1,4 @@
+class Cog
+  class Error < RuntimeError
+  end
+end

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/lib/rspec/cog.rb
+++ b/lib/rspec/cog.rb
@@ -1,0 +1,4 @@
+require 'rspec/core'
+
+require 'rspec/cog/matchers'
+require 'rspec/cog/setup'

--- a/lib/rspec/cog/matchers.rb
+++ b/lib/rspec/cog/matchers.rb
@@ -1,0 +1,8 @@
+# This is what you want to use for commands that return raw text
+RSpec::Matchers.define :respond_with_text do |expected|
+  match do |command|
+    @actual = command.response.content["body"]
+    @actual == expected
+  end
+  diffable
+end

--- a/lib/rspec/cog/matchers.rb
+++ b/lib/rspec/cog/matchers.rb
@@ -6,3 +6,12 @@ RSpec::Matchers.define :respond_with_text do |expected|
   end
   diffable
 end
+
+# Use this when dealing with commands that return data structures
+RSpec::Matchers.define :respond_with do |expected|
+  match do |command|
+    @actual = command.response.content
+    @actual == expected
+  end
+  diffable
+end

--- a/lib/rspec/cog/setup.rb
+++ b/lib/rspec/cog/setup.rb
@@ -1,0 +1,72 @@
+require 'yaml'
+require 'securerandom'
+require 'rspec/core'
+
+module Cog::RSpec::Setup
+  extend RSpec::SharedContext
+
+  before(:each) do
+    # Ensure a clean ENV, as far as Cog cares
+    # NOTE: Does not do anything pertaining to dynamic config
+    # variables yet
+    ENV.delete_if{|name, value| name.start_with?("COG_")}
+  end
+
+  let(:base_dir) do
+    # Cog Ruby commands expect to be run from a script in the
+    # top-level directory. This code thus assumes that the tests are
+    # being run from that same top-level directory.
+    File.absolute_path(Dir.pwd)
+  end
+
+  let(:config_file) do
+    File.join(base_dir, "config.yaml")
+  end
+
+  let(:bundle_name) do
+    # Read the bundle name from the bundle configuration; no need to
+    # repeat that everywhere
+    YAML.load(File.read(config_file))["name"]
+  end
+
+  let!(:bundle) do
+    # This is `let!` instead of `let` because this call actually
+    # *creates* the bundle module that our commands live in; we want
+    # to ensure that this gets called before we start doing anything else
+    Cog::Bundle.new(bundle_name, base_dir: base_dir, config_file: config_file)
+  end
+
+  let(:command_name){ raise "Must supply a :command_name!" }
+
+  let(:command) do
+    Object.const_get("CogCmd::#{bundle_name.capitalize}::#{command_name.capitalize}").new
+  end
+
+  let(:invocation_id) { SecureRandom.uuid }
+
+  let(:service_root) { "http://localhost:4002" }
+
+  let(:cog_env) { [] }
+
+  def run_command(args: [])
+    ENV["COG_COMMAND"]       = command_name
+    ENV["COG_INVOCATION_ID"] = invocation_id
+    ENV["COG_SERVICES_ROOT"] = service_root
+
+    # populate arguments
+    ENV["COG_ARGC"] = args.size.to_s
+    args.each_with_index{|arg, i| ENV["COG_ARGV_#{i}"] = arg.to_s}
+
+    # TODO: Set options as needed
+
+    # TODO: receive a single input on STDIN, multiple for :fetch_input
+
+    # Expose previous inputs on STDIN
+    expect(STDIN).to receive(:read).and_return(cog_env.to_json)
+
+    # Use allow because not all commands will need to do this
+    allow(command).to receive(:fetch_input).and_return(cog_env)
+    command.run_command
+  end
+
+end

--- a/lib/rspec/cog/setup.rb
+++ b/lib/rspec/cog/setup.rb
@@ -48,7 +48,7 @@ module Cog::RSpec::Setup
 
   let(:cog_env) { [] }
 
-  def run_command(args: [])
+  def run_command(args: [], options: {})
     ENV["COG_COMMAND"]       = command_name
     ENV["COG_INVOCATION_ID"] = invocation_id
     ENV["COG_SERVICES_ROOT"] = service_root
@@ -57,7 +57,11 @@ module Cog::RSpec::Setup
     ENV["COG_ARGC"] = args.size.to_s
     args.each_with_index{|arg, i| ENV["COG_ARGV_#{i}"] = arg.to_s}
 
-    # TODO: Set options as needed
+    # populate_options
+    if !options.keys.empty?
+      ENV["COG_OPTS"] = options.keys.join(",")
+      options.each{|k,v| ENV["COG_OPT_#{k.upcase}"] = v.to_s}
+    end
 
     # TODO: receive a single input on STDIN, multiple for :fetch_input
 


### PR DESCRIPTION
Now we can write unit tests for `cog-rb`-based commands!

Take a look at cogcmd/format#6 for its use.
