### PR TITLE
Allow commands to abort pipeline execution

### DIFF
--- a/lib/cog/response.rb
+++ b/lib/cog/response.rb
@@ -5,7 +5,7 @@ class Cog
   class Response
     LOG_LEVELS = [ :debug, :info, :warn, :err, :error ]
 
-    attr_accessor :template, :content
+    attr_accessor :template, :content, :stop
 
     def []=(key, value)
       @content ||= {}
@@ -13,6 +13,8 @@ class Cog
     end
 
     def send
+      write "COGCMD_ACTION: stop" unless @stop.nil?
+
       return if content.nil?
 
       write "COG_TEMPLATE: #{@template}" unless @template.nil?

--- a/lib/cog/response.rb
+++ b/lib/cog/response.rb
@@ -17,7 +17,7 @@ class Cog
     end
 
     def send
-      write "COGCMD_ACTION: stop" unless @aborted.nil?
+      write "COGCMD_ACTION: abort" unless @aborted.nil?
       write "COG_TEMPLATE: #{@template}" unless @template.nil?
 
       return if content.nil?

--- a/lib/cog/response.rb
+++ b/lib/cog/response.rb
@@ -5,19 +5,22 @@ class Cog
   class Response
     LOG_LEVELS = [ :debug, :info, :warn, :err, :error ]
 
-    attr_accessor :template, :content, :stop
+    attr_accessor :template, :content, :aborted
 
     def []=(key, value)
       @content ||= {}
       @content[key] = value
     end
 
+    def abort
+      @aborted = true
+    end
+
     def send
-      write "COGCMD_ACTION: stop" unless @stop.nil?
+      write "COGCMD_ACTION: stop" unless @aborted.nil?
+      write "COG_TEMPLATE: #{@template}" unless @template.nil?
 
       return if content.nil?
-
-      write "COG_TEMPLATE: #{@template}" unless @template.nil?
 
       case content.class
       when String

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.1.7"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
Implements Ruby command-facing API for the design described in [#691](https://github.com/operable/cog/issues/691).

Fixes [#691](https://github.com/operable/cog/issues/691)
