### PR TITLE
Add template management support

### DIFF
--- a/bin/cogrb
+++ b/bin/cogrb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'rake'
+require 'cog/config'
+
+rake = Rake::Application.new
+rake.init('cogrb')
+Rake.application = rake
+
+rake.standard_exception_handling do
+  task_dir = File.join(File.dirname(__FILE__), '..', 'lib', 'tasks')
+  task_files = FileList.new(File.join(task_dir, '*.rake'))
+  task_files.each { |file| rake.add_import(file) }
+  rake.load_imports
+  rake.top_level
+end

--- a/cog-rb.gemspec
+++ b/cog-rb.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = ["cogrb"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rake", "~> 11.2"
   spec.add_development_dependency "bundler", "~> 1.11"
 end

--- a/lib/cog/config.rb
+++ b/lib/cog/config.rb
@@ -3,16 +3,49 @@ require "yaml"
 
 class Cog
   class Config
+    attr_reader :config_file, :data, :stale
+
     def initialize(config_file)
-      @config = YAML.load(File.read(config_file))
+      @config_file = config_file
+      @data = YAML.load(File.read(@config_file))
+      @stale = false
     end
 
     def dump
-      YAML.dump(@config)
+      YAML.dump(@data)
     end
 
     def [](key)
-      @config[key.to_s]
+      @data[key.to_s]
+    end
+
+    def []=(key, value)
+      @data[key.to_s] = value
+      @stale = true
+    end
+
+    def update_version(version = nil)
+      if !version.nil?
+        @data[version] = version
+      else
+        segments = @data['version'].split('.')
+        segments[-1] = segments.last.to_i + 1
+        @data['version'] = segments.join('.')
+      end
+    end
+
+    def save
+      return unless @stale
+
+      contents = YAML.dump(@data)
+      File.open(@config_file, 'w') do |out|
+        out.write(contents)
+        @stale = false
+      end
+    end
+
+    def stale?
+      @stale
     end
   end
 end

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end

--- a/lib/tasks/cog.rake
+++ b/lib/tasks/cog.rake
@@ -1,0 +1,35 @@
+namespace :template do
+  desc "Update templates in configuration file"
+  task :update do
+    config_file = FileList.new('config.y?ml').first
+    config = Cog::Config.new(config_file)
+
+    puts "Current bundle configuration version is #{config['version']}."
+
+    templates = FileList.new('templates/*/*.mustache')
+    return if templates.nil? || templates.size == 0
+
+    config['templates'] ||= {}
+    templates.each do |file|
+      (provider, template) = file.split('/')[-2..-1]
+      template.gsub!(/\.mustache\z/, '')
+      template_content = File.read(file)
+
+      config['templates'][provider] ||= {}
+      prev_content = config['templates'][provider][template]
+
+      if template_content != prev_content
+        puts "Updating bundle configuration for template #{provider}/#{template}."
+        config['templates'][provider][template] = template_content
+      end
+    end
+
+    if config.stale?
+      config.update_version
+      puts "Writing new configuration file for version #{config['version']}."
+      config.save
+    else
+      puts "No updated templates found. Configuration not updated."
+    end
+  end
+end


### PR DESCRIPTION
- Adds a bin/cogrb binstub Rake wrapper around lib/tasks/*.rake
- Update Cog::Config to support updating and rewriting config
- Adds `cogrb template:update` to read templates/providers/*.mustache and update the configuration file with the contents if changed
