### PR TITLE
change expect to allow for stdin in run_command

### DIFF
--- a/lib/rspec/cog/setup.rb
+++ b/lib/rspec/cog/setup.rb
@@ -73,7 +73,8 @@ module Cog::RSpec::Setup
     # TODO: receive a single input on STDIN, multiple for :fetch_input
 
     # Expose previous inputs on STDIN
-    expect(STDIN).to receive(:read).and_return(cog_env.to_json)
+    # We use allow because not all commands receive input
+    allow(STDIN).to receive(:read).and_return(cog_env.to_json)
 
     # Use allow because not all commands will need to do this
     allow(command).to receive(:fetch_input).and_return(cog_env)


### PR DESCRIPTION
Use `allow` instead of `expect` when reading from `STDIN` because some commands don't take input.
