### PR TITLE
Only read from STDIN if there's data there

### DIFF
--- a/lib/cog/request.rb
+++ b/lib/cog/request.rb
@@ -1,4 +1,3 @@
-
 require 'json'
 
 class Cog
@@ -8,7 +7,7 @@ class Cog
     def initialize
       @args = populate_args
       @options = populate_options
-      @input = JSON.parse(STDIN.read)
+      @input = (STDIN.tty?) ? {} : JSON.parse(STDIN.read)
     end
 
     private


### PR DESCRIPTION
For real-world usage, `STDIN` won't be attached to a TTY (because
we'll always be passing in JSON input), but for testing / instruction
purposes, it's useful to not hang indefinitely if nothing is passed (or
have to pass in `"{}"` as a dummy value).
