### PR TITLE
Bundles no longer require config.yaml to execute

### DIFF
--- a/lib/cog/bundle.rb
+++ b/lib/cog/bundle.rb
@@ -1,58 +1,49 @@
 class Cog
   class Bundle
-    attr_reader :name, :config
+    attr_reader :name
 
-    def initialize(name, base_dir: nil, config_file: nil)
+    def initialize(name, base_dir: nil)
       @name = name
       @base_dir = base_dir || File.dirname($0)
-      @config = load_config(config_file || File.join(@base_dir, 'config.yaml'))
       @module = create_bundle_module
-
-      load_commands
     end
 
     def create_bundle_module
       return if Object.const_defined?('CogCmd')
-
       Object.const_set('CogCmd', Module.new)
       CogCmd.const_set(@name.capitalize, Module.new)
     end
 
-    def load_config(path=nil)
-      path ||= File.join(@base_dir, 'config.yaml')
-      Cog::Config.new(path)
-    end
-
-    def load_commands
-      @config[:commands].each do |command, config|
-        command_path = command.split('-')
-        require File.join(@base_dir, 'lib', 'cog_cmd', @name, *command_path)
-      end
-    end
-
-    def run_command
-      command = ENV['COG_COMMAND']
+    def command_instance(command_name)
+      command_path = command_name.split('-')
+      require File.join(@base_dir, 'lib', 'cog_cmd', @name, *command_path)
 
       # translate snake-case command names to camel case
-      command_class = command.gsub(/(\A|_)([a-z])/) { $2.upcase }
+      command_class = command_name.gsub(/(\A|_)([a-z])/) { $2.upcase }
 
       # convert hyphenated command names into class hierarchies,
       # e.g. template-list becomes Template::List.
       command_class = command_class.split('-').map{ |seg| seg.capitalize }.join('::')
 
-      target = @module.const_get(command_class).new
+      @module.const_get(command_class).new
+    end
+
+    def run_command
+      command = ENV['COG_COMMAND']
+      target = command_instance(command)
       target.execute
-    # Abort will end command execution and abort the pipeline
     rescue Cog::Abort => msg
+      # Abort will end command execution and abort the pipeline
       response = Cog::Response.new
       response['body'] = msg
       response.abort
       response.send
-    # Stop will end command execution but the pipeline will continue
     rescue Cog::Stop => msg
+      # Stop will end command execution but the pipeline will continue
       response = Cog::Response.new
       response['body'] = msg
       response.send
     end
+
   end
 end


### PR DESCRIPTION
The metaprogramming we were using to set up the code was requiring a
`config.yaml` file be present at execution time. However, this was only
being used to get the names of the bundle's commands; it would use this
to then require all the appropriate command implementation files. In
reality, we only really need to load the one file corresponding to the
command we're currently executing.

This change now only does the metaprogramming on the current command's
implementation, eliminating the need for there to be a `config.yaml`.

(Long term, we'll remove the metaprogramming altogether, but this is a
simplifying step in that direction.)
