### PR TITLE
Command loading and rspec helper fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.3
+
+* Bugfix to allow rspec support to work with current Cog::Bundle API
+* Bugfix to skip creation of intermediate modules in the command hierarchy if they are already defined
+
 ## 0.3.2
 
 The 0.3.1 release inadvertently omitted the `docker:release` task. This has been corrected.

--- a/lib/cog/bundle.rb
+++ b/lib/cog/bundle.rb
@@ -9,9 +9,15 @@ class Cog
     end
 
     def create_bundle_module
-      return if Object.const_defined?('CogCmd')
-      Object.const_set('CogCmd', Module.new)
-      CogCmd.const_set(@name.capitalize, Module.new)
+      module_name = @name.capitalize
+
+      Object.const_set('CogCmd', Module.new) unless Object.const_defined?('CogCmd')
+
+      if CogCmd.const_defined?(module_name)
+        CogCmd.const_get(module_name)
+      else
+        CogCmd.const_set(module_name, Module.new)
+      end
     end
 
     def command_instance(command_name)

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/lib/rspec/cog/setup.rb
+++ b/lib/rspec/cog/setup.rb
@@ -33,20 +33,13 @@ module Cog::RSpec::Setup
     # This is `let!` instead of `let` because this call actually
     # *creates* the bundle module that our commands live in; we want
     # to ensure that this gets called before we start doing anything else
-    Cog::Bundle.new(bundle_name, base_dir: base_dir, config_file: config_file)
+    Cog::Bundle.new(bundle_name, base_dir: base_dir)
   end
 
   let(:command_name){ raise "Must supply a :command_name!" }
 
   let(:command) do
-    # translate snake-case command names to camel case
-    command_class = command_name.gsub(/(\A|_)([a-z])/) { $2.upcase }
-
-    # convert hyphenated command names into class hierarchies,
-    # e.g. template-list becomes Template::List.
-    command_class = command_class.split('-').map{ |seg| seg.capitalize }.join('::')
-
-    Object.const_get("CogCmd::#{bundle_name.capitalize}::#{command_class}").new
+    bundle.command_instance(command_name)
   end
 
   let(:invocation_id) { SecureRandom.uuid }

--- a/lib/tasks/cog.rake
+++ b/lib/tasks/cog.rake
@@ -1,10 +1,13 @@
-config_file = FileList.new("config.yml", "config.yaml").first
+config_file = FileList.new("config.y*ml").first
 config = Cog::Config.new(config_file)
 docker_image = config['docker'].nil? ? nil : "#{config['docker']['image']}:#{config['docker']['tag']}"
 
 namespace :template do
   desc "Update templates in configuration file"
-  task :update do
+  task :update do |t, args|
+    puts args.join(",")
+    exit
+
     puts "Current bundle configuration version is #{config['version']}."
 
     templates = FileList.new('templates/*')

--- a/lib/tasks/cog.rake
+++ b/lib/tasks/cog.rake
@@ -1,4 +1,4 @@
-config_file = FileList.new('config.y?ml').first
+config_file = FileList.new("config.yml", "config.yaml").first
 config = Cog::Config.new(config_file)
 docker_image = config['docker'].nil? ? nil : "#{config['docker']['image']}:#{config['docker']['tag']}"
 

--- a/lib/tasks/cog.rake
+++ b/lib/tasks/cog.rake
@@ -4,10 +4,7 @@ docker_image = config['docker'].nil? ? nil : "#{config['docker']['image']}:#{con
 
 namespace :template do
   desc "Update templates in configuration file"
-  task :update do |t, args|
-    puts args.join(",")
-    exit
-
+  task :update, [ :mode ] do |t, args|
     puts "Current bundle configuration version is #{config['version']}."
 
     templates = FileList.new('templates/*')
@@ -29,7 +26,7 @@ namespace :template do
     end
 
     if config.stale?
-      config.update_version
+      config.update_version unless args[:mode] == 'dev'
       puts "Writing new configuration file for version #{config['version']}."
       config.save
     else


### PR DESCRIPTION
* Fixes a bug with loading command code if some modules were already loaded
* Fixes  rspec to work with recent changes to the Cog::Bundle API which no longer require the config_file
