### PR TITLE
Correctly abort and print an error

### DIFF
--- a/lib/cog/bundle.rb
+++ b/lib/cog/bundle.rb
@@ -38,16 +38,16 @@ class Cog
       command = ENV['COG_COMMAND']
       target = command_instance(command)
       target.execute
-    rescue Cog::Abort => msg
+    rescue Cog::Abort => exception
       # Abort will end command execution and abort the pipeline
       response = Cog::Response.new
-      response['body'] = msg
+      response.content = exception.message
       response.abort
       response.send
-    rescue Cog::Stop => msg
+    rescue Cog::Stop => exception
       # Stop will end command execution but the pipeline will continue
       response = Cog::Response.new
-      response['body'] = msg
+      response['body'] = exception.message
       response.send
     end
 

--- a/lib/cog/response.rb
+++ b/lib/cog/response.rb
@@ -17,16 +17,16 @@ class Cog
     end
 
     def send
-      write "COGCMD_ACTION: abort" unless @aborted.nil?
-      write "COG_TEMPLATE: #{@template}" unless @template.nil?
+      write "COGCMD_ACTION: abort" if aborted
+      write "COG_TEMPLATE: #{@template}" if @template
 
       return if content.nil?
 
-      case content.class
+      case content
       when String
-        write @content.join('').to_json
+        write content
       else
-        write "JSON\n" + @content.to_json
+        write "JSON\n" + content.to_json
       end
     end
 


### PR DESCRIPTION
Raising `Cog::Abort` was broken as it was returning JSON.

![screen shot 2016-11-10 at 1 28 54 pm](https://cloud.githubusercontent.com/assets/228734/20193253/379b74c8-a75b-11e6-85c9-db377d684c91.png)

This fixes it so it just prints a string.