### PR TITLE
Add exception handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.4.0: Unreleased
+
+* Add exception handling support. You can now define a regular expression and a
+  block to be called when an exception whose class matches the pattern is
+  received. This should generally be defined in your `cog-command`. The block
+  will be called with the exception and `Cog::Command` instance that was
+  executing. Exceptions that are not matched by a pattern will be handled
+  normally. Here's an example:
+
+  ```
+  Cog.error_handler.add(/Aws::.*/) do |exception, command|
+    Cog.return_error("#{command.name} error: #{exception.message}")
+  end
+  ```
+
 ## 0.3.5
 
 * Bugfix for "warning: toplevel constant RSpec referenced by Cog::RSpec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0: Unreleased
+## 0.4.0
 
 * Add exception handling support. You can now define a regular expression and a
   block to be called when an exception whose class matches the pattern is

--- a/lib/cog.rb
+++ b/lib/cog.rb
@@ -2,6 +2,7 @@
 require_relative 'cog/bundle'
 require_relative 'cog/config'
 require_relative 'cog/command'
+require_relative 'cog/exception_handler'
 require_relative 'cog/request'
 require_relative 'cog/response'
 require_relative 'cog/version'
@@ -14,6 +15,24 @@ class Cog
   def self.bundle(name)
     bundle = Cog::Bundle.new(name)
     yield bundle if block_given?
-    bundle.run_command
+
+    begin
+      bundle.run_command
+    rescue Exception => ex
+      error_handler.handle_exception(
+        exception: ex,
+        command: bundle.command
+      )
+    end
+  end
+
+  def self.error_handler
+    @@handler ||= Cog::ExceptionHandler.new
+  end
+
+  def self.return_error(message)
+    puts "COGCMD_ACTION: abort"
+    puts message
+    exit(0)
   end
 end

--- a/lib/cog/bundle.rb
+++ b/lib/cog/bundle.rb
@@ -20,6 +20,10 @@ class Cog
       end
     end
 
+    def command
+      @command ||= command_instance(ENV['COG_COMMAND'])
+    end
+
     def command_instance(command_name)
       command_path = command_name.split('-')
       require File.join(@base_dir, 'lib', 'cog_cmd', @name, *command_path)
@@ -35,9 +39,7 @@ class Cog
     end
 
     def run_command
-      command = ENV['COG_COMMAND']
-      target = command_instance(command)
-      target.execute
+      command.execute
     rescue Cog::Abort => exception
       # Abort will end command execution and abort the pipeline
       response = Cog::Response.new

--- a/lib/cog/command.rb
+++ b/lib/cog/command.rb
@@ -5,6 +5,10 @@ class Cog
   class Command
     attr_writer :memory_key, :config
 
+    def name
+      ENV['COG_COMMAND']
+    end
+
     def request
       @request ||= Cog::Request.new
     end

--- a/lib/cog/exception_handler.rb
+++ b/lib/cog/exception_handler.rb
@@ -1,0 +1,33 @@
+class Cog::ExceptionHandler
+  attr_accessor :handlers
+
+  def initialize
+    @handlers = {}
+  end
+
+  def add(pattern, &block)
+    @handlers[pattern] = block
+  end
+
+  def handle_exception(exception:, command:)
+    handlers.keys.each do |pattern|
+      if pattern.match(exception.class.to_s)
+        log_exception(exception, command)
+        handlers[pattern].call(exception, command)
+      else
+        raise exception
+      end
+    end
+  end
+
+  private
+
+  def log_exception(exception, command)
+    log_message = {
+      command_name: command.name,
+      message: exception.message,
+      stack_trace: exception.backtrace
+    }
+    puts "COGCMD_ERROR: #{log_message.to_json}"
+  end
+end

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.3.7"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
This PR allows you to optionally define a set of regular expression patterns and exception handler callbacks that will be called when an exception is raised that matches the pattern. 

From the CHANGELOG:

> Add exception handling support. You can now define a regular expression and a
  block to be called when an exception whose class matches the pattern is
  received. This should generally be defined in your `cog-command`. The block
  will be called with the exception and `Cog::Command` instance that was
  executing. Exceptions that are not matched by a pattern will be handled
  normally. Here's an example:
>
>  ```
>  Cog.error_handler.add(/Aws::.*/) do |exception, command|
>    Cog.return_error("#{command.name} error: #{exception.message}")
>  end
>  ```
