### PR TITLE
Only read STDIN once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.3
+
+* Memoize Cog::Request.input as a class variable so that we don't try
+  to read STDIN more than once if we initialize request more than once
+  for any reason.
+
 ## 0.4.2
 
 * Minor change to `cogrb template:update` to remove line wrapping of values.

--- a/lib/cog/request.rb
+++ b/lib/cog/request.rb
@@ -2,15 +2,18 @@ require 'json'
 
 class Cog
   class Request
-    attr_reader :options, :args, :input
+    attr_reader :options, :args
 
     def initialize
       @args = populate_args
       @options = populate_options
-      @input = (STDIN.tty?) ? {} : JSON.parse(STDIN.read)
     end
 
     private
+
+    def input
+      @@input = (STDIN.tty?) ? {} : JSON.parse(STDIN.read)
+    end
 
     def populate_args
       (0 .. (ENV['COG_ARGC'].to_i - 1)).map { |n| ENV["COG_ARGV_#{n}"] }

--- a/lib/cog/version.rb
+++ b/lib/cog/version.rb
@@ -1,3 +1,3 @@
 class Cog
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
There were some cases where we could potentially call Cog::Request.new more than once within a command execution which would fail since we had already called `STDIN.read`. The specific case was in the rescue for `Cog::Abort` where we would call `command_name`. 

This memoizes the request input in a class variable to protect against that.